### PR TITLE
Add guzzle request client class 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,11 @@
       "guzzlehttp/guzzle": "^7.0"
    },
    "require-dev": {
+      "dg/bypass-finals": "^1.4",
       "friendsofphp/php-cs-fixer": "^3",
       "overtrue/phplint": "^2.3",
-      "phpunit/phpunit": "^9.5",
       "phpstan/phpstan": "^1",
+      "phpunit/phpunit": "^9.5",
       "squizlabs/php_codesniffer": "^3.5"
    },
    "scripts": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+	bootstrapFiles:
+		- tests/phpstan-bootstrap.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          backupGlobals="false"
          backupStaticAttributes="false"

--- a/src/Request/Client.php
+++ b/src/Request/Client.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Lee\Request;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
+
+final class Client
+{
+    private GuzzleClient $client;
+
+    public function __construct(array $options)
+    {
+        if ($options) {
+            $this->validateOptions($options);
+        }
+
+        $options['allow_redirects'] = false;
+
+        $this->client = new GuzzleClient($options);
+    }
+
+    public function get(string $url): Response
+    {
+        return $this->client->get($url);
+    }
+
+    /**
+     * Guzzle client implementation do not raise any error/exception upon invalid requests
+     * options, this method validates request options to ensure they can be safely passed
+     * into Guzzle client and throws an exception if any of the options is not supported.
+     *
+     * @throws \LogicException
+     */
+    private function validateOptions(array $options): void
+    {
+        foreach (array_keys($options) as $name) {
+            if (!defined(sprintf('%s::%s', RequestOptions::class, strtoupper($name)))) {
+                throw new \LogicException("Option '$name' does not supported as a Guzzle request option.");
+            }
+        }
+    }
+}

--- a/src/Request/Client.php
+++ b/src/Request/Client.php
@@ -1,17 +1,18 @@
 <?php
 
-// todo add @internal
-
 namespace Lee\Request;
 
 use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RequestOptions;
+use Psr\Http\Message\ResponseInterface;
 
 final class Client
 {
     private GuzzleClient $client;
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function __construct(array $options)
     {
         if ($options) {
@@ -23,7 +24,7 @@ final class Client
         $this->client = new GuzzleClient($options);
     }
 
-    public function get(string $url): Response
+    public function get(string $url): ResponseInterface
     {
         return $this->client->get($url);
     }
@@ -32,6 +33,8 @@ final class Client
      * Guzzle client implementation do not raise any error/exception upon invalid requests
      * options, this method validates request options to ensure they can be safely passed
      * into Guzzle client and throws an exception if any of the options is not supported.
+     *
+     * @param array<string, mixed> $options
      *
      * @throws \LogicException
      */

--- a/src/Request/Client.php
+++ b/src/Request/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+// todo add @internal
+
 namespace Lee\Request;
 
 use GuzzleHttp\Client as GuzzleClient;

--- a/src/Request/Client.php
+++ b/src/Request/Client.php
@@ -6,6 +6,9 @@ use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @internal
+ */
 final class Client
 {
     private GuzzleClient $client;

--- a/src/Tracker.php
+++ b/src/Tracker.php
@@ -42,7 +42,7 @@ class Tracker
      */
     public static function trackFromUrl(string $url, array $requestOptions = []): Set
     {
-        $tracker = new static($requestOptions);
+        $tracker = new self($requestOptions);
 
         return $tracker->track($url);
     }

--- a/src/Tracker.php
+++ b/src/Tracker.php
@@ -10,6 +10,9 @@ class Tracker
 {
     private Client $client;
 
+    /**
+     * @param array<string, mixed> $requestOptions
+     */
     public function __construct(array $requestOptions = [])
     {
         $this->client = new Client($requestOptions);
@@ -34,6 +37,9 @@ class Tracker
         return $results;
     }
 
+    /**
+     * @param array<string, mixed> $requestOptions
+     */
     public static function trackFromUrl(string $url, array $requestOptions = []): Set
     {
         $tracker = new static($requestOptions);

--- a/tests/Request/ClientTest.php
+++ b/tests/Request/ClientTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Lee\Tests\Request;
+
+use GuzzleHttp\Client as GuzzleHttpClient;
+use GuzzleHttp\Psr7\Response;
+use Lee\Request\Client;
+use PHPUnit\Framework\TestCase;
+
+class ClientTest extends TestCase
+{
+    public function testConstructorWithInvalidRequestOptions(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("Option 'foo' does not supported as a Guzzle request option.");
+
+        new Client([
+            'timeout' => 3,
+            'foo' => 'bar',
+        ]);
+    }
+
+    public function testGetWithValidUrl(): void
+    {
+        $url = 'https://bit.ly/grpc-intro';
+
+        $guzzle = $this->getMockBuilder(GuzzleHttpClient::class)
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $guzzle->expects($this->once())
+            ->method('get')
+            ->with($url)
+            ->willReturn(new Response(301));
+
+        $client = $this->getMockBuilder(Client::class)
+            ->onlyMethods([])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $property = getReflectedProperty(Client::class, 'client');
+        $property->setValue($client, $guzzle);
+
+        $this->assertInstanceOf(Response::class, $client->get($url));
+    }
+
+    public function testGetWithInvalidUrl(): void
+    {
+        $guzzle = $this->getMockBuilder(GuzzleHttpClient::class)
+            ->onlyMethods([])
+            ->getMock();
+
+        $client = $this->getMockBuilder(Client::class)
+            ->onlyMethods([])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $property = getReflectedProperty(Client::class, 'client');
+        $property->setValue($client, $guzzle);
+
+        $this->expectException(\GuzzleHttp\Exception\GuzzleException::class);
+        $client->get('I am not valid URL');
+    }
+}

--- a/tests/TrackerTest.php
+++ b/tests/TrackerTest.php
@@ -2,74 +2,152 @@
 
 namespace Lee\Tests;
 
-use Lee\Result\Result;
-use Lee\Result\Set;
+use GuzzleHttp\Psr7\Response;
+use Lee\Request\Client;
 use Lee\Tracker;
 use PHPUnit\Framework\TestCase;
 
 class TrackerTest extends TestCase
 {
-    public function testTrackOnSpecificShortenBitlyUrl(): void
+    public function testTrackWithInvalidUrl(): void
     {
-        $url = 'https://bit.ly/grpc-intro';
-        $mock = $this->getMockBuilder(Tracker::class)
-                     ->setConstructorArgs([$url])
+        $invalidUrl = 'I am not valid URL';
+
+        $tracker = $this->getMockBuilder(Tracker::class)
+                     ->onlyMethods([])
+                     ->disableOriginalConstructor()
                      ->getMock();
 
-        $finalResult = new Result(200, 'https://www.slideshare.net/williamyeh/grpc-238408172/williamyeh/grpc-238408172', []);
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("The giving URL '$invalidUrl' is invalid.");
 
-        $expected = (new Set())
-            ->add(new Result(301, $url, ['location' => $finalResult->getUrl()]))
-            ->add($finalResult);
-
-        $mock->expects($this->once())
-             ->method('track')
-             ->willReturn($expected);
-
-        $actual = $mock->track();
-
-        $this->assertEquals($expected, $actual);
-
-        // SetTest
-        $this->assertEquals([
-            [
-                'code' => 301,
-                'url' => 'https://bit.ly/grpc-intro',
-                'headers' => ['location' => 'https://www.slideshare.net/williamyeh/grpc-238408172/williamyeh/grpc-238408172'],
-            ],
-            [
-                'code' => 200,
-                'url' => 'https://www.slideshare.net/williamyeh/grpc-238408172/williamyeh/grpc-238408172',
-                'headers' => [],
-            ],
-        ], $actual->asArray());
-        $resultsJson = '[{"code":301,"url":"https:\/\/bit.ly\/grpc-intro","headers":{"location":"https:\/\/'
-            . 'www.slideshare.net\/williamyeh\/grpc-238408172\/williamyeh\/grpc-238408172"}},{"code":200,"url":"ht'
-            . 'tps:\/\/www.slideshare.net\/williamyeh\/grpc-238408172\/williamyeh\/grpc-238408172","headers":[]}]';
-        $this->assertEquals($resultsJson, $actual->asJson());
-        $this->assertEquals($finalResult, $actual->getFinal());
-        $this->assertEquals(2, $actual->count());
-
-        // ResultTest
-        $this->assertEquals(200, $finalResult->getCode());
-        $this->assertEquals('https://www.slideshare.net/williamyeh/grpc-238408172/williamyeh/grpc-238408172', $finalResult->getUrl());
-        $this->assertEquals([], $finalResult->getHeaders());
+        $tracker->track($invalidUrl);
     }
 
-    public function testGetUrl(): void
+    public function testTrackWithoutRedirects(): void
     {
-        $url = 'https://bit.ly/grpc-intro';
-        $tracker = new Tracker($url);
+        $url = 'https://www.php.net/';
 
-        $this->assertSame($url, $tracker->getUrl());
+        $response = $this->getMockBuilder(Response::class)
+            ->onlyMethods(['getStatusCode', 'getHeaders', 'hasHeader'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $response->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $response->expects($this->once())
+            ->method('getHeaders')
+            ->willReturn(['content-type' => 'text/html']);
+
+        $response->expects($this->once())
+            ->method('hasHeader')
+            ->with('Location')
+            ->willReturn(false);
+
+        $client = $this->getMockBuilder(Client::class)
+            ->onlyMethods(['get'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $client->expects($this->once())
+            ->method('get')
+            ->with($url)
+            ->willReturn($response);
+
+        $tracker = $this->getMockBuilder(Tracker::class)
+            ->onlyMethods([])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $property = getReflectedProperty(Tracker::class, 'client');
+        $property->setValue($tracker, $client);
+
+        $results = $tracker->track($url);
+        $final = $results->getFinal();
+
+        $this->assertEquals(200, $final->getCode());
+        $this->assertEquals($url, $final->getUrl());
+        $this->assertEquals(['content-type' => 'text/html'], $final->getHeaders());
     }
 
-    public function testGetUrlShouldThrowInvalidArgumentException(): void
+    public function testTrackWithOneRedirect(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $originalUrl = 'https://bit.ly/grpc-intro';
+        $finalUrl = 'https://www.slideshare.net/williamyeh/grpc-238408172/williamyeh/grpc-238408172';
 
-        $url = 'I am not valid URL';
-        $tracker = new Tracker($url);
-        $tracker->track();
+        // mock the first response object
+        $firstResponse = $this->getMockBuilder(Response::class)
+            ->onlyMethods(['getStatusCode', 'getHeaders', 'hasHeader', 'getHeader'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $firstResponse->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(301);
+
+        $firstResponse->expects($this->once())
+            ->method('getHeaders')
+            ->willReturn(['location' => $finalUrl]);
+
+        $firstResponse->expects($this->once())
+            ->method('hasHeader')
+            ->with('Location')
+            ->willReturn(true);
+
+        $firstResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Location')
+            ->willReturn([$finalUrl]);
+
+        // get mocked class of the second response object
+        $secondResponse = $this->getMockBuilder(Response::class)
+            ->onlyMethods(['getStatusCode', 'getHeaders', 'hasHeader'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $secondResponse->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $secondResponse->expects($this->once())
+            ->method('getHeaders')
+            ->willReturn(['content-type' => 'text/html']);
+
+        $secondResponse->expects($this->once())
+            ->method('hasHeader')
+            ->with('Location')
+            ->willReturn(false);
+
+        $client = $this->getMockBuilder(Client::class)
+            ->onlyMethods(['get'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $client->expects($this->exactly(2))
+            ->method('get')
+            ->withConsecutive([$originalUrl], [$finalUrl])
+            ->willReturnOnConsecutiveCalls($firstResponse, $secondResponse);
+
+        $tracker = $this->getMockBuilder(Tracker::class)
+            ->onlyMethods([])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $property = getReflectedProperty(Tracker::class, 'client');
+        $property->setValue($tracker, $client);
+
+        $resultsArr = $tracker->track($originalUrl)->asArray();
+        $originalUrlResult = $resultsArr[0];
+        $finalUrlResult = $resultsArr[1];
+
+        $this->assertEquals(301, $originalUrlResult['code']);
+        $this->assertEquals($originalUrl, $originalUrlResult['url']);
+        $this->assertEquals(['location' => $finalUrl], $originalUrlResult['headers']);
+
+        $this->assertEquals(200, $finalUrlResult['code']);
+        $this->assertEquals($finalUrl, $finalUrlResult['url']);
+        $this->assertEquals(['content-type' => 'text/html'], $finalUrlResult['headers']);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,24 @@
+<?php
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+// remove all final keywords from our test classes to be able to create mock classes for them
+DG\BypassFinals::enable();
+
+/**
+ * Returns an accessible reflected property for the giving class property.
+ *
+ * @throws LogicException
+ */
+function getReflectedProperty(string $className, string $name): ReflectionProperty
+{
+    if (!class_exists($className)) {
+        throw new LogicException("Sorry, you cannot get a reflection property in the class '$className', because it does not exist.");
+    }
+
+    $reflection = new ReflectionClass($className);
+    $property = $reflection->getProperty($name);
+    $property->setAccessible(true);
+
+    return $property;
+}

--- a/tests/phpstan-bootstrap.php
+++ b/tests/phpstan-bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+/*
+ * Fix phpstan errors when mocking final classes:
+ * "Return type of call to method PHPUnit\Framework\MockObject\MockBuilder<Lee\Request\Client>::getMock() contains unresolvable type."
+ *
+ * The following code fixes the problem and removes the final keywords from
+ * test classes at runtime before phpstan starts doing static analyzing.
+ *
+ * See the following link for more information:
+ * @link https://github.com/phpstan/phpstan-phpunit/issues/57
+ */
+
+DG\BypassFinals::enable();


### PR DESCRIPTION
## CHANGES

* Added guzzle request client class and integrated with the base `Tracker` class.
* Added `@throws` phpdoc tag for the `Tracker::validateUrl` method and removed the phpdoc description.
* Removed the `Tracker::url` property and `Tracker::getUrl` method, since the URL is now stateless.
* The method `Tracker::trackFromUrl` is not removed (but the implementation changed), as we have discussed [here](https://github.com/peter279k/url-tracker/issues/2#issuecomment-1326247177).
* Added unit tests and integrated the `dg/bypass-finals` library to allow mocking final classes.